### PR TITLE
pwnable.kr: Add a new link in README

### DIFF
--- a/pwnable.kr/README.md
+++ b/pwnable.kr/README.md
@@ -10,6 +10,7 @@ For more details, please see [pwnable.kr](http://pwnable.kr/play.php).
 - [flag](flag/README.md)
 - [random](random/README.md)
 - [input](input/README.md)
+- [mistake](mistake/README.md)
 - [cmd1](cmd1/README.md)
 
 ## Rookiss


### PR DESCRIPTION
Add a new link for "mistake" in README.

Fixes: 74e96ec (pwnable.kr: Add write-up for mistake)
Signed-off-by: Xie Ziyao <xieziyao@outlook.com>